### PR TITLE
Clearing up the readme

### DIFF
--- a/letsdnsocloud/README.md
+++ b/letsdnsocloud/README.md
@@ -29,7 +29,8 @@ Use a custom domain with Let's Encrypt on Hass.io without having to open any por
   - Optional: Forward desired public facing port (TCP & UDP) to your Hass.io local IP & port (default local port is 8123).
 
   &nbsp;&nbsp;&nbsp;&nbsp;_ Example: Forward port 443 to local port if you want to access externally without specifying a port. i.e_ https://yourdomain.com _rather than_ https://yourdomain.com:1234
-
+  &nbsp;&nbsp;&nbsp;&nbsp;_ Note: If you do not forward any ports, make sure your FQDN (Domain name) resolves to HomeAssistant locally
+  
 ### 4. Hass.io config
   - Install plugin using /addons directory or GIT
   - Edit config with your CloudFlare Global API Key, your CloudFlare email address and domain.

--- a/letsdnsocloud/README.md
+++ b/letsdnsocloud/README.md
@@ -2,7 +2,7 @@
 
 ## Hass.io Custom Domain with free CloudFlare DNS hosting, DDNS and Let's Encrypt (DNS Challenge)
 
-Use a custom domain with Let's Encrypt on Hass.io without having to open port 80 to the world.
+Use a custom domain with Let's Encrypt on Hass.io without having to open any port to the world.
 
 ### Features:
 
@@ -20,19 +20,22 @@ Use a custom domain with Let's Encrypt on Hass.io without having to open port 80
   - Sign up for free account.
   - Add your base domain (no need to create any DNS records).
   - Make a note of the CloudFlare name servers.
-  - Turn off the free SSL option under the Crypto menu (SSL to Off & Disable Universal SSL).
+  - Optional: Turn off the free SSL option under the Crypto menu (SSL to Off & Disable Universal SSL).
 
 ### 2. Domain Registrar
   - Change nameservers for your domain to point to Cloudflare.
 
 ### 3. Home Router
-  - Forward desired public facing port (TCP & UDP) to your Hass.io local IP & port (default local port is 8123).
+  - Optional: Forward desired public facing port (TCP & UDP) to your Hass.io local IP & port (default local port is 8123).
 
-  &nbsp;&nbsp;&nbsp;&nbsp;_Forward port 443 if you want to access externally without specifying a port. i.e_ https://yourdomain.com _rather than_ https://yourdomain.com:1234
+  &nbsp;&nbsp;&nbsp;&nbsp;_ Example: Forward port 443 to local port if you want to access externally without specifying a port. i.e_ https://yourdomain.com _rather than_ https://yourdomain.com:1234
 
 ### 4. Hass.io config
-  - Edit config file with your CloudFlare Global API Key, your CloudFlare email address and domain.
+  - Install plugin using /addons directory or GIT
+  - Edit config with your CloudFlare Global API Key, your CloudFlare email address and domain.
   - Hit start and wait for it to create the certificates.
+
+### 4. Homeassistant config
   - Add the following to your configuration.yaml:
 ```
   http:

--- a/letsdnsocloud/README.md
+++ b/letsdnsocloud/README.md
@@ -20,7 +20,8 @@ Use a custom domain with Let's Encrypt on Hass.io without having to open any por
   - Sign up for free account.
   - Add your base domain (no need to create any DNS records).
   - Make a note of the CloudFlare name servers.
-  - Optional: Turn off the free SSL option under the Crypto menu (SSL to Off & Disable Universal SSL).
+  - Option 1: Set the free SSL option under the crypto menu to "Full (strict)" and enable Universal SSL.
+  - Option 2: Turn off the free SSL option under the Crypto menu (SSL to Off & Disable Universal SSL).
 
 ### 2. Domain Registrar
   - Change nameservers for your domain to point to Cloudflare.


### PR DESCRIPTION
- Forwarding ports are optional, you can use the certificate (if you setup DNS right) locally without any forwarded ports just fine
- Turning off Cloudflare SSL is optional, you could also use strict ssl
- Instead of using the config file, more user friendly to use the web GUI after install
- Plugin could also be installed using GIT