### PR TITLE
Added openssl binary

### DIFF
--- a/letsdnsocloud/Dockerfile
+++ b/letsdnsocloud/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG C.UTF-8
 
 # Setup base
 ARG DEHYDRATED_VERSION
-RUN apk add --no-cache jq curl libressl \
+RUN apk add --no-cache jq curl libressl openssl \
   && curl -s -o /usr/bin/dehydrated https://raw.githubusercontent.com/lukas2511/dehydrated/v$DEHYDRATED_VERSION/dehydrated \
   && chmod a+x /usr/bin/dehydrated
 


### PR DESCRIPTION
Install the openssl binary, to avoid the error below when starting the addon. It happens in certain scenarios.
"This script requires an openssl binary"